### PR TITLE
Fix image digest extraction and restrict image platform to linux/amd64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lightsail v1.40.3
 	github.com/aws/smithy-go v1.20.3
 	github.com/docker/docker v27.1.1+incompatible
+	github.com/google/go-cmp v0.6.0
 	github.com/moby/term v0.5.0
+	github.com/opencontainers/image-spec v1.1.0
 	golang.org/x/mod v0.20.0
 )
 
@@ -36,7 +38,6 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect

--- a/internal/assert.go
+++ b/internal/assert.go
@@ -1,0 +1,29 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// AssertError asserts that an error matches the expected error string.
+// If wantErr is empty, it expects no error. Otherwise, it expects the error
+// message to exactly match wantErr.
+func AssertError(t *testing.T, wantErr string, err error) {
+	t.Helper()
+	errStr := ""
+	if err != nil {
+		errStr = err.Error()
+	}
+	if diff := cmp.Diff(wantErr, errStr); diff != "" {
+		t.Errorf("error mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Assert asserts that two values are equal.
+func Assert(t *testing.T, what string, want, got any) {
+	t.Helper()
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("%s mismatch (-want +got):\n%s", what, diff)
+	}
+}

--- a/internal/cs/dockerengine.go
+++ b/internal/cs/dockerengine.go
@@ -8,9 +8,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/docker/docker/api/types/image"
@@ -18,12 +20,37 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/moby/term"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+type platformError struct {
+	wantPlatform *ocispec.Platform
+	cause        error
+}
+
+func (pe *platformError) Error() string {
+	return fmt.Sprintf("image does not provide %s/%s platform",
+		pe.wantPlatform.OS, pe.wantPlatform.Architecture)
+}
+
+func (pe *platformError) Unwrap() error { return pe.cause }
 
 // DockerEngine defines a subset of client-side
 // operations against local Docker Engine, relevant to lightsailctl.
 type DockerEngine struct {
-	c *client.Client
+	it interface {
+		ImageTag(ctx context.Context, source, target string) error
+	}
+	ir interface {
+		ImageRemove(
+			ctx context.Context, imageID string, options image.RemoveOptions,
+		) ([]image.DeleteResponse, error)
+	}
+	ip interface {
+		ImagePush(
+			ctx context.Context, image string, options image.PushOptions,
+		) (io.ReadCloser, error)
+	}
 }
 
 // RemoteImage combines remote server auth details, address
@@ -44,46 +71,69 @@ func NewDockerEngine(ctx context.Context) (*DockerEngine, error) {
 		return nil, err
 	}
 	dc.NegotiateAPIVersion(ctx)
-	return &DockerEngine{c: dc}, nil
+	return &DockerEngine{it: dc, ir: dc, ip: dc}, nil
 }
 
 func (e *DockerEngine) TagImage(ctx context.Context, source, target string) error {
-	return e.c.ImageTag(ctx, source, target)
+	return e.it.ImageTag(ctx, source, target)
 }
 
 func (e *DockerEngine) UntagImage(ctx context.Context, imageID string) error {
-	_, err := e.c.ImageRemove(ctx, imageID, image.RemoveOptions{})
+	_, err := e.ir.ImageRemove(ctx, imageID, image.RemoveOptions{})
 	return err
 }
 
-func (e *DockerEngine) PushImage(ctx context.Context, remoteImage RemoteImage) (digest string, err error) {
+func (e *DockerEngine) PushImage(ctx context.Context, remoteImage RemoteImage) (string, error) {
 	authBytes, err := json.Marshal(remoteImage.AuthConfig)
 	if err != nil {
 		return "", err
 	}
-	pushRes, err := e.c.ImagePush(ctx, remoteImage.Ref(), image.PushOptions{
+
+	platform := &ocispec.Platform{OS: "linux", Architecture: "amd64"}
+	pushOutput, err := e.ip.ImagePush(ctx, remoteImage.Ref(), image.PushOptions{
 		RegistryAuth: base64.URLEncoding.EncodeToString(authBytes),
+		Platform:     platform,
 	})
 	if err != nil {
+		if platformErrorRE(platform).MatchString(err.Error()) {
+			return "", &platformError{wantPlatform: platform, cause: err}
+		}
 		return "", err
 	}
-	defer pushRes.Close()
+	defer pushOutput.Close()
 
+	var digestFromStatus, digestFromAux string
 	termFd, isTerm := term.GetFdInfo(os.Stderr)
 	if err = jsonmessage.DisplayJSONMessagesStream(
-		// Skip statuses that have irrelevant details such as repo address.
-		skipStatuses(pushRes, remoteImage.ServerAddress, remoteImage.Tag),
+		scanStatuses(&digestFromStatus, pushOutput,
+			remoteImage.ServerAddress, remoteImage.Tag),
 		os.Stderr, termFd, isTerm,
-		extractDigest(&digest)); err != nil {
+		extractDigestFromAux(&digestFromAux),
+	); err != nil {
+		var je *jsonmessage.JSONError
+		if errors.As(err, &je) {
+			if platformErrorRE(platform).MatchString(je.Message) {
+				return "", &platformError{wantPlatform: platform, cause: err}
+			}
+		}
 		return "", err
 	}
-	if digest == "" {
-		return "", errors.New("image push response does not contain the image digest")
+
+	switch {
+	case digestFromStatus != "":
+		// Got digest from a newer Docker Engine.
+		return digestFromStatus, nil
+	case digestFromAux != "":
+		// Got digest from an older Docker Engine.
+		return digestFromAux, nil
 	}
-	return digest, nil
+	return "", errors.New("image push response does not contain the image digest")
 }
 
-func skipStatuses(input io.Reader, s ...string) io.Reader {
+// scanStatuses omits statuses that have irrelevant details such as repo
+// address, and intercepts the image digest, if any, that newer Docker Engines
+// emit.
+func scanStatuses(digest *string, input io.Reader, skips ...string) io.Reader {
 	r, w := io.Pipe()
 	go func() {
 		defer w.Close()
@@ -93,31 +143,48 @@ func skipStatuses(input io.Reader, s ...string) io.Reader {
 		for {
 			m := jsonmessage.JSONMessage{}
 			if err := dec.Decode(&m); err != nil {
-				if err != io.EOF {
-					log.Printf("skipStatuses: %v", err)
+				if !errors.Is(err, io.EOF) && err.Error() != "http: read on closed response body" {
+					log.Printf("scanStatuses: %v", err)
 				}
 				break
 			}
-			for _, skip := range s {
+			// Newer Docker Engines emit an image digest via message status
+			// field.
+			if match := digestStatusRE.FindStringSubmatch(m.Status); len(match) == 2 {
+				*digest = match[1]
+			}
+			for _, skip := range skips {
 				if strings.Contains(m.Status, skip) {
 					continue InputLoop
 				}
 			}
 			if err := enc.Encode(m); err != nil {
-				log.Printf("skipStatuses: %v", err)
+				log.Printf("scanStatuses: %v", err)
 			}
 		}
 	}()
 	return r
 }
 
-func extractDigest(p *string) func(jsonmessage.JSONMessage) {
+// extractDigestFromAux attempts to extract an image digest emitted by older
+// Docker Engines.
+func extractDigestFromAux(digest *string) func(jsonmessage.JSONMessage) {
 	return func(m jsonmessage.JSONMessage) {
 		aux := struct{ Digest string }{}
 		if err := json.Unmarshal(*m.Aux, &aux); err != nil {
 			log.Printf("extractDigest: %v", err)
 			return
 		}
-		*p = aux.Digest
+		*digest = aux.Digest
 	}
 }
+
+func platformErrorRE(platform *ocispec.Platform) *regexp.Regexp {
+	return regexp.MustCompile(`does not (provide|match) the specified platform ` +
+		regexp.QuoteMeta(fmt.Sprintf("(%s/%s)", platform.OS, platform.Architecture)))
+}
+
+// In newer Docker Engines, the last status message contains the image digest,
+// and it looks like this:
+// "... digest: sha256:cafe1234cafe1234cafe1234cafe1234cafe1234cafe1234abce5678cdef9012 size: 1819"
+var digestStatusRE = regexp.MustCompile(`digest: (sha256:[a-f0-9]{64})`)

--- a/internal/cs/dockerengine_test.go
+++ b/internal/cs/dockerengine_test.go
@@ -1,39 +1,194 @@
 package cs
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/aws/lightsailctl/internal"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/pkg/jsonmessage"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func TestExtractDigest(t *testing.T) {
-	got := ""
-	badAux := json.RawMessage("42")
-	extractDigest(&got)(jsonmessage.JSONMessage{Aux: &badAux})
-	if got != "" {
-		t.Errorf("unexpected got: %q", got)
+const exampleDigest = "sha256:cafe1234cafe1234cafe1234cafe1234cafe1234cafe1234abce5678cdef9012"
+
+type fakeImageTagger struct {
+	gotSource, gotTarget string
+	fail                 error
+}
+
+func (f *fakeImageTagger) ImageTag(_ context.Context, source, target string) error {
+	f.gotSource, f.gotTarget = source, target
+	return f.fail
+}
+
+type fakeImageRemover struct {
+	gotImageID string
+	fail       error
+}
+
+func (f *fakeImageRemover) ImageRemove(
+	_ context.Context, imageID string, _ image.RemoveOptions,
+) ([]image.DeleteResponse, error) {
+	f.gotImageID = imageID
+	if f.fail != nil {
+		return nil, f.fail
 	}
-	wantDigest := "sha256:b95cf9b496720e43b12ce435775d5e337a6648147825c0fc8fc0ff93616c69a0"
-	goodAux := json.RawMessage(`{"digest": "` + wantDigest + `"}`)
-	extractDigest(&got)(jsonmessage.JSONMessage{Aux: &goodAux})
-	if got != wantDigest {
-		t.Errorf("got: %q", got)
-		t.Logf("want: %q", wantDigest)
+	return []image.DeleteResponse{}, nil
+}
+
+type fakeImagePusher struct {
+	gotImage    string
+	gotOptions  image.PushOptions
+	fail        error
+	statusError string
+	digestInAux bool
+}
+
+func (f *fakeImagePusher) ImagePush(
+	_ context.Context, image string, options image.PushOptions,
+) (io.ReadCloser, error) {
+	f.gotImage = image
+	f.gotOptions = options
+
+	if f.fail != nil {
+		return nil, f.fail
+	}
+
+	badStatus := ""
+	if f.statusError != "" {
+		badStatus = fmt.Sprintf(`{"errorDetail":{"message":"%s"}}\n`, f.statusError)
+	}
+
+	digestStatus := fmt.Sprintf(`{"status":"whatever ... digest: %s ..."}`, exampleDigest)
+	if f.digestInAux {
+		digestStatus = fmt.Sprintf(`{"aux":{"digest":"%s"}}`, exampleDigest)
+	}
+
+	return io.NopCloser(strings.NewReader(strings.TrimSpace(fmt.Sprintf(`
+{"status":"Waiting","progressDetail":{},"id":"d3a003bc9307"}
+{"status":"Waiting","progressDetail":{},"id":"4f4fb700ef54"}
+{"status":"Waiting","progressDetail":{},"id":"4056d2e51b69"}
+{"status":"Layer already exists","progressDetail":{},"id":"d3a003bc9307"}
+{"status":"Layer already exists","progressDetail":{},"id":"4f4fb700ef54"}
+{"status":"Layer already exists","progressDetail":{},"id":"4056d2e51b69"}
+%s%s
+`, badStatus, digestStatus)))), nil
+}
+
+func TestDockerEngine(t *testing.T) {
+	ctx := context.Background()
+
+	tagger := &fakeImageTagger{}
+
+	e := &DockerEngine{it: tagger}
+
+	err := e.TagImage(ctx, "httpd:latest", "example.com/httpd:latest")
+	internal.AssertError(t, "", err)
+	internal.Assert(t, "source", "httpd:latest", tagger.gotSource)
+	internal.Assert(t, "target", "example.com/httpd:latest", tagger.gotTarget)
+
+	tagger.fail = io.EOF
+	err = e.TagImage(ctx, "mcp:latest", "example.com/mcp:latest")
+	internal.AssertError(t, "EOF", err)
+	internal.Assert(t, "source", "mcp:latest", tagger.gotSource)
+	internal.Assert(t, "target", "example.com/mcp:latest", tagger.gotTarget)
+
+	remover := &fakeImageRemover{}
+	e = &DockerEngine{ir: remover}
+	err = e.UntagImage(ctx, "go:v1.25")
+	internal.AssertError(t, "", err)
+	internal.Assert(t, "imageID", "go:v1.25", remover.gotImageID)
+
+	remover.fail = io.EOF
+	err = e.UntagImage(ctx, "go:v1.23")
+	internal.AssertError(t, "EOF", err)
+	internal.Assert(t, "imageID", "go:v1.23", remover.gotImageID)
+
+	for _, test := range []struct {
+		name    string
+		pusher  fakeImagePusher
+		wantErr string
+	}{
+		{
+			name: "pushed ok",
+		},
+		{
+			name:   "pushed ok, digest in aux",
+			pusher: fakeImagePusher{digestInAux: true},
+		},
+		{
+			name:    "pushed with error",
+			pusher:  fakeImagePusher{fail: io.EOF},
+			wantErr: "EOF",
+		},
+		{
+			name:    "pushed with platform mismatch in status",
+			pusher:  fakeImagePusher{statusError: "... does not provide the specified platform (linux/amd64)"},
+			wantErr: "image does not provide linux/amd64 platform",
+		},
+		{
+			name:    "pushed with platform mismatch in error",
+			pusher:  fakeImagePusher{fail: errors.New("... does not match the specified platform (linux/amd64)")},
+			wantErr: "image does not provide linux/amd64 platform",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			e := &DockerEngine{ip: &test.pusher}
+			digest, err := e.PushImage(ctx, RemoteImage{
+				AuthConfig: registry.AuthConfig{
+					Username: "user", Password: "42", ServerAddress: "example.com/httpd",
+				},
+				Tag: "v2.0.0",
+			})
+			internal.AssertError(t, test.wantErr, err)
+			if test.wantErr != "" {
+				return
+			}
+			internal.Assert(t, "digest", exampleDigest, digest)
+			internal.Assert(t, "image", "example.com/httpd:v2.0.0", test.pusher.gotImage)
+			internal.Assert(t, "options", image.PushOptions{
+				// This is just base64 encoding of the auth config, provided above.
+				RegistryAuth: "eyJ1c2VybmFtZSI6InVzZXIiLCJwYXNzd29yZCI6IjQyIiwic2VydmVyYWRkcmVzcyI6ImV4YW1wbGUuY29tL2h0dHBkIn0=",
+				Platform:     &ocispec.Platform{OS: "linux", Architecture: "amd64"},
+			}, test.pusher.gotOptions)
+		})
 	}
 }
 
-func Example_skipStatuses() {
-	r := skipStatuses(
-		strings.NewReader(`
+// Tests that digests from older Docker Engines are handled.
+func TestExtractDigestFromAux(t *testing.T) {
+	digest := ""
+	badAux := json.RawMessage("42")
+	extractDigestFromAux(&digest)(jsonmessage.JSONMessage{Aux: &badAux})
+	if digest != "" {
+		t.Errorf("unexpected got: %q", digest)
+	}
+	goodAux := json.RawMessage(`{"digest": "` + exampleDigest + `"}`)
+	extractDigestFromAux(&digest)(jsonmessage.JSONMessage{Aux: &goodAux})
+	if digest != exampleDigest {
+		t.Errorf("got: %q", digest)
+		t.Logf("want: %q", exampleDigest)
+	}
+}
+
+func Example_scanStatuses() {
+	digest := ""
+	r := scanStatuses(
+		&digest,
+		strings.NewReader(fmt.Sprintf(`
 		{"status": "keep me"}
 		{"status": "xyz skip1 abc"}
 		{"status": "also keep me!"}
-		{"status": "\tskip2"}`),
+		{"status": "\tskip2"}
+		{"status": "... digest: %s ..."}`, exampleDigest)),
 		"skip2", "skip1",
 	)
 	if _, err := io.Copy(os.Stdout, r); err != nil {
@@ -43,4 +198,5 @@ func Example_skipStatuses() {
 	// Output:
 	// {"status":"keep me"}
 	// {"status":"also keep me!"}
+	// {"status":"... digest: sha256:cafe1234cafe1234cafe1234cafe1234cafe1234cafe1234abce5678cdef9012 ..."}
 }

--- a/internal/cs/pushimage.go
+++ b/internal/cs/pushimage.go
@@ -65,7 +65,7 @@ func PushImage(ctx context.Context, in *PushImageInput, lio LightsailImageOperat
 
 	digest, err := imgo.PushImage(ctx, remoteImage)
 	if err != nil {
-		return err
+		return fmt.Errorf("image %q push error: %w", in.Image, err)
 	}
 
 	registered, err := lio.RegisterContainerImage(

--- a/internal/cs/pushimage_test.go
+++ b/internal/cs/pushimage_test.go
@@ -82,7 +82,7 @@ func TestPushImageErrors(t *testing.T) {
 		},
 		{
 			imgo: fakeImageOperator{failToPush: true},
-			want: `failed: push "123456789012.dkr.ecr.so-fake-2.amazonaws.com/sr:1611800397000000000-c5h66p35cpjmg"`,
+			want: `image "nginx:latest" push error: failed: push "123456789012.dkr.ecr.so-fake-2.amazonaws.com/sr:1611800397000000000-c5h66p35cpjmg"`,
 		},
 	} {
 		t.Run(strconv.Itoa(i+1), func(t *testing.T) {

--- a/internal/version.go
+++ b/internal/version.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const Version Semver = "v1.0.6"
+const Version Semver = "v1.0.7-fix95fix100"
 
 type Semver string
 


### PR DESCRIPTION
- Extract image digests from status messages (newer Docker) with fallback to aux field (older Docker)
- Explicitly specify `linux/amd64` platform to avoid multiplatform pushes that Lightsail doesn't support

Closes: #95 
Closes: #100 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
