### PR TITLE
Make version injectable via goreleaser ldflags

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -93,7 +93,7 @@ func (c *OperationConfig) awsConfig(ctx context.Context) (aws.Config, error) {
 	var opts []func(*config.LoadOptions) error
 
 	opts = append(opts, config.WithAPIOptions([]func(*smithyMW.Stack) error{
-		middleware.AddUserAgentKeyValue("lightsailctl", internal.Version.String()),
+		middleware.AddUserAgentKeyValue("lightsailctl", internal.Version().String()),
 	}))
 
 	if c.Region != "" {
@@ -152,7 +152,7 @@ func invokeOperation(ctx context.Context, in *Input, debugLog *log.Logger) error
 			}
 		})
 
-		internal.CheckForUpdates(ctx, debugLog, ls, internal.Version)
+		internal.CheckForUpdates(ctx, debugLog, ls, internal.Version())
 
 		r, err := parsePushContainerImagePayload(in.Payload)
 		if err != nil {

--- a/internal/version.go
+++ b/internal/version.go
@@ -9,7 +9,10 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const Version Semver = "v1.0.7"
+// Managed by ldflags -X in .goreleaser.yaml.
+var versionString = "v1.0.7"
+
+func Version() Semver { return Semver(versionString) }
 
 type Semver string
 

--- a/internal/version_test.go
+++ b/internal/version_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestVersionGlobalIsValid(t *testing.T) {
-	if !internal.Version.IsValid() {
-		t.Errorf("internal.Version value %q is not a valid semver",
-			string(internal.Version))
+	if version := internal.Version(); !version.IsValid() {
+		t.Errorf("internal.Version value %q is not a valid semver", string(version))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 	case len(os.Args) > 1 && pluginPattern.MatchString(os.Args[1]):
 		pluginMain(os.Args[0]+" "+os.Args[1], os.Args[2:])
 	case len(os.Args) > 1 && getverPattern.MatchString(os.Args[1]):
-		fmt.Println(internal.Version)
+		fmt.Println(internal.Version())
 	default:
 		log.Fatalf("%s can't be used directly, it is meant to be invoked by AWS CLI", os.Args[0])
 	}


### PR DESCRIPTION
Convert `internal.Version` from a const to a function backed by a package var, so goreleaser can inject the release version at build time via Go's ldflags -X (already wired in .goreleaser.yaml).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
